### PR TITLE
Fixed duplicate records bug

### DIFF
--- a/resources/usr/bin/nirvana2vcf.py
+++ b/resources/usr/bin/nirvana2vcf.py
@@ -101,8 +101,6 @@ def merge_files( vcf_file, json_file, out_file):
 
             # No transcript annotation so include the unannotated vcf line
             if 'transcripts' not in variant.keys() or 'refSeq' not in variant [ 'transcripts' ]:
-
-                out_fh.write(str( rec ))
                 continue
 
             for transcript in variant [ 'transcripts' ][ 'refSeq' ]:


### PR DESCRIPTION
Fixed a bug which caused variants which do not intersect with a refseq to appear twice in output vcf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_nirvana2vcf/7)
<!-- Reviewable:end -->
